### PR TITLE
go fmt & error를 리턴

### DIFF
--- a/practice_problem/chapter5/problem03/serialization.go
+++ b/practice_problem/chapter5/problem03/serialization.go
@@ -8,8 +8,8 @@ import (
 
 type ID int64
 type Task struct {
-	Title string 	`json:"title"`
-	ID ID			`json:"id"`
+	Title string `json:"title"`
+	ID    ID     `json:"id"`
 }
 
 func (i *ID) UnmarshalJSON(data []byte) error {
@@ -20,7 +20,10 @@ func (i *ID) UnmarshalJSON(data []byte) error {
 	//fmt.Println(reflect.TypeOf(v))
 	switch x := v.(type) {
 	case string:
-		s, _ := strconv.ParseInt(x, 10, 64)
+		s, err := strconv.ParseInt(x, 10, 64)
+		if err != nil {
+			return err
+		}
 		*i = ID(s)
 	case float64:
 		*i = ID(x)

--- a/practice_problem/chapter5/problem03/serialization_test.go
+++ b/practice_problem/chapter5/problem03/serialization_test.go
@@ -9,25 +9,24 @@ import (
 
 func TestTask_UnmarshalJSON(t *testing.T) {
 	cases := []struct {
-		in []byte
+		in  []byte
 		out Task
-	} {
+	}{
 		{
 			[]byte(`{"Title":"title1","ID":64}`),
-			Task {
+			Task{
 				Title: "title1",
-				ID: 64,
+				ID:    64,
 			},
 		},
 		{
 			[]byte(`{"Title":"title2","ID":"64"}`),
 			Task{
 				Title: "title2",
-				ID: 64,
+				ID:    64,
 			},
 		},
 	}
-
 
 	for i, c := range cases {
 		var task Task


### PR DESCRIPTION
- go fmt
- strconv.ParseInt()의 에러를 무시하던 것을 리턴하게끔. 어차피 UnmarshalJSON 함수가 에러를 리턴하므로.